### PR TITLE
Fix s3 path extract

### DIFF
--- a/tensorboardX/record_writer.py
+++ b/tensorboardX/record_writer.py
@@ -66,7 +66,7 @@ class S3RecordWriter(object):
         self.close()
 
     def bucket_and_path(self):
-        bp = self.path.split("/")
+        bp = self.path.split("/")[2:]
         bucket = bp[0]
         path = self.path[1 + len(bucket):]
         return bucket, path


### PR DESCRIPTION
Paths like `s3://abc.def/ghi/jkl` are not handled correctly.